### PR TITLE
Makefile: support `srcdir` and `basedir` variables for out-of-tree builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,13 @@
 
 .SUFFIXES: .cxx .c .o .h .a
 
+srcdir ?= .
+basedir ?= $(srcdir)/..
+
 AR = ar
 CC = gcc
 CXX = g++
-CXXFLAGS = -std=c++17 -pedantic -DCURSES -DSCI_LEXER -I../include -I../src -Wall
+CXXFLAGS = -std=c++17 -pedantic -DCURSES -DSCI_LEXER -I$(basedir)/include -I$(basedir)/src -Wall
 ifdef DEBUG
   CXXFLAGS += -DDEBUG -g
 else
@@ -20,8 +23,8 @@ sci = AutoComplete.o CallTip.o CaseConvert.o CaseFolder.o CellBuffer.o ChangeHis
   MarginView.o PerLine.o PositionCache.o RESearch.o RunStyles.o ScintillaBase.o Selection.o \
   Style.o UniConversion.o UniqueString.o ViewStyle.o XPM.o
 
-vpath %.h ../src ../include
-vpath %.cxx ../src
+vpath %.h $(srcdir) $(basedir)/src $(basedir)/include
+vpath %.cxx $(srcdir) $(basedir)/src
 
 all: $(scintilla)
 $(sci) PlatCurses.o ScintillaCurses.o: %.o: %.cxx

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ basedir ?= $(srcdir)/..
 AR = ar
 CC = gcc
 CXX = g++
-CXXFLAGS = -std=c++17 -pedantic -DCURSES -DSCI_LEXER -I$(basedir)/include -I$(basedir)/src -Wall
+CXX_BASE_FLAGS = -std=c++17 -pedantic -DCURSES -DSCI_LEXER -I$(basedir)/include -I$(basedir)/src -Wall
 ifdef DEBUG
-  CXXFLAGS += -DDEBUG -g
+  CXX_BASE_FLAGS += -DDEBUG -g
 else
-  CXXFLAGS += -DNDEBUG -Os
+  CXX_BASE_FLAGS += -DNDEBUG -Os
 endif
 CURSES_FLAGS =
 
@@ -28,7 +28,7 @@ vpath %.cxx $(srcdir) $(basedir)/src
 
 all: $(scintilla)
 $(sci) PlatCurses.o ScintillaCurses.o: %.o: %.cxx
-	$(CXX) $(CXXFLAGS) $(CURSES_FLAGS) -c $<
+	$(CXX) $(CXX_BASE_FLAGS) $(CXXFLAGS) $(CURSES_FLAGS) -c $<
 $(scintilla): $(sci) PlatCurses.o ScintillaCurses.o
 	$(AR) rc $@ $^
 	touch $@


### PR DESCRIPTION
This is similar to what scintilla/gtk/makefile does.
  You are supposed to run the Scintilla Makefile from the build directory
  and point it to the source directory, eg.:
```
mkdir -p build/scintilla/bin
make -C build/scintilla/bin -f src/scintilla/scinterm/Makefile srcdir=$PWD/src/scintilla/scinterm
```
You can overwrite basedir as well in order to completely separate Scinterm from Scintilla:
```
make -C build/scintilla/bin -f src/scinterm/Makefile srcdir=$PWD/src/scinterm basedir=$PWD/src/scintilla
```
Previously this could be done by setting VPATH.

The second commit allows you to pass in CXXFLAGS from the Make command line or from the environment.