### PR TITLE
basic support for monochrome terminals

### DIFF
--- a/PlatCurses.cxx
+++ b/PlatCurses.cxx
@@ -364,10 +364,16 @@ void SurfaceImpl::DrawTextClipped(PRectangle rc, const Font *font_, XYPOSITION y
 void SurfaceImpl::DrawTextTransparent(
 	PRectangle rc, const Font *font_, XYPOSITION ybase, std::string_view text, ColourRGBA fore) {
 	if (static_cast<int>(rc.top) > getmaxy(win) - 1) return;
-	auto left = static_cast<int>(rc.left);
-	attr_t attrs = left >= clip.left ? mvwinch(win, static_cast<int>(rc.top), left) : 0;
-	short pair = PAIR_NUMBER(attrs), unused, back = COLOR_BLACK;
-	if (pair > 0 && !isCallTip) pair_content(pair, &unused, &back);
+	short back = COLOR_BLACK;
+	if (!isCallTip) {
+		auto left = static_cast<int>(rc.left);
+		attr_t attrs = left >= clip.left ? mvwinch(win, static_cast<int>(rc.top), left) : 0;
+		short pair = PAIR_NUMBER(attrs), unused;
+		if (pair > 0)
+			pair_content(pair, &unused, &back);
+		else if (attrs & A_REVERSE) // monochrome terminal
+			back = COLOR_WHITE;
+	}
 	DrawTextNoClip(rc, font_, ybase, text, fore, SCI_COLORS[back]);
 }
 

--- a/PlatCurses.cxx
+++ b/PlatCurses.cxx
@@ -212,7 +212,7 @@ void SurfaceImpl::PolyLine(const Point * /*pts*/, size_t /*npts*/, Stroke /*stro
 // normally drawn as polygons are handled in `DrawLineMarker()`.
 void SurfaceImpl::Polygon(const Point *pts, size_t npts, FillStroke fillStroke) {
 	ColourRGBA &back = fillStroke.fill.colour;
-	wattr_set(win, 0, term_color_pair(back, COLOR_WHITE), nullptr); // invert
+	wattrset(win, term_color_attr(back, COLOR_WHITE)); // invert
 	if (pts[0].y < pts[npts - 1].y) // up arrow
 		mvwaddstr(win, static_cast<int>(pts[0].y), static_cast<int>(pts[npts - 1].x - 2), "▲");
 	else if (pts[0].y > pts[npts - 1].y) // down arrow
@@ -235,13 +235,13 @@ void SurfaceImpl::FillRectangle(PRectangle rc, Fill fill) {
 		pixmapColor = fill.colour;
 		return;
 	}
-	wattr_set(win, 0, term_color_pair(COLOR_WHITE, fill.colour), nullptr);
+	wattrset(win, term_color_attr(COLOR_WHITE, fill.colour));
 	chtype ch = ' ';
 	if (fabs(rc.left - static_cast<int>(rc.left)) > 0.1) {
 		// If rc.left is a fractional value (e.g. 4.5) then whitespace dots are being drawn. Draw
 		// them appropriately.
 		// TODO: set color to vs.whitespaceColours.fore and back.
-		wcolor_set(win, term_color_pair(COLOR_BLACK, COLOR_BLACK), nullptr);
+		wattrset(win, term_color_attr(COLOR_BLACK, COLOR_BLACK));
 		rc.right = static_cast<int>(rc.right), ch = ACS_BULLET | A_BOLD;
 	}
 	for (int y = static_cast<int>(rc.top); y < rc.bottom; y++)
@@ -275,7 +275,8 @@ void SurfaceImpl::AlphaRectangle(PRectangle rc, XYPOSITION /*cornerSize*/, FillS
 		attr_t attrs = mvwinch(win, y, x) & A_ATTRIBUTES;
 		short pair = PAIR_NUMBER(attrs), fore = COLOR_WHITE, unused;
 		if (pair > 0) pair_content(pair, &fore, &unused);
-		mvwchgat(win, y, x, 1, attrs, term_color_pair(fore, fill), nullptr);
+		attrs |= term_color_attr(fore, fill);
+		mvwchgat(win, y, x, 1, attrs, PAIR_NUMBER(attrs), nullptr);
 	}
 }
 
@@ -297,7 +298,7 @@ void SurfaceImpl::Stadium(PRectangle /*rc*/, FillStroke /*fillStroke*/, Ends /*e
 void SurfaceImpl::Copy(PRectangle rc, Point /*from*/, Surface & /*surfaceSource*/) {
 	// TODO: handle indent guide highlighting.
 	if (rc.left - 1 < clip.left) return;
-	wattr_set(win, 0, term_color_pair(COLOR_BLACK, COLOR_BLACK), nullptr);
+	wattrset(win, term_color_attr(COLOR_BLACK, COLOR_BLACK));
 	mvwaddch(win, static_cast<int>(rc.top), static_cast<int>(rc.left - 1), '|' | A_BOLD);
 }
 
@@ -324,7 +325,7 @@ int grapheme_width(const char *s) {
 void SurfaceImpl::DrawTextNoClip(PRectangle rc, const Font *font_, XYPOSITION /*ybase*/,
 	std::string_view text, ColourRGBA fore, ColourRGBA back) {
 	attr_t attrs = dynamic_cast<const FontImpl *>(font_)->attrs;
-	wattr_set(win, attrs, term_color_pair(fore, back), nullptr);
+	wattrset(win, attrs | term_color_attr(fore, back));
 	if (rc.left < clip.left) {
 		// Do not overwrite margin text.
 		auto clip_chars = static_cast<int>(clip.left - rc.left);
@@ -434,7 +435,7 @@ void SurfaceImpl::DrawLineMarker(
 	const PRectangle &rcWhole, const Font *fontForCharacter, int /*tFold*/, const void *data) {
 	// TODO: handle fold marker highlighting.
 	auto marker = reinterpret_cast<const LineMarker *>(data);
-	wattr_set(win, 0, term_color_pair(marker->fore, marker->back), nullptr);
+	wattrset(win, term_color_attr(marker->fore, marker->back));
 	int top = static_cast<int>(rcWhole.top), left = static_cast<int>(rcWhole.left);
 	switch (marker->markType) {
 	case MarkerSymbol::Circle: mvwaddstr(win, top, left, "●"); return;
@@ -476,7 +477,7 @@ void SurfaceImpl::DrawLineMarker(
 
 // Draws the text representation of a wrap marker.
 void SurfaceImpl::DrawWrapMarker(PRectangle rcPlace, bool isEndMarker, ColourRGBA wrapColour) {
-	wattr_set(win, 0, term_color_pair(wrapColour, COLOR_BLACK), nullptr);
+	wattrset(win, term_color_attr(wrapColour, COLOR_BLACK));
 	mvwaddstr(
 		win, static_cast<int>(rcPlace.top), static_cast<int>(rcPlace.left), isEndMarker ? "↩" : "↪");
 }
@@ -484,7 +485,7 @@ void SurfaceImpl::DrawWrapMarker(PRectangle rcPlace, bool isEndMarker, ColourRGB
 // Draws the text representation of a tab arrow.
 void SurfaceImpl::DrawTabArrow(PRectangle rcTab, const ViewStyle &vsDraw) {
 	// TODO: set color to vs.whitespaceColours.fore and back.
-	wattr_set(win, 0, term_color_pair(COLOR_BLACK, COLOR_BLACK), nullptr);
+	wattrset(win, term_color_attr(COLOR_BLACK, COLOR_BLACK));
 	for (int i = static_cast<int>(std::max(rcTab.left - 1, clip.left)); i < rcTab.right; i++)
 		mvwaddch(win, static_cast<int>(rcTab.top), i, '-' | A_BOLD);
 	char tail = vsDraw.tabDrawMode == TabDrawMode::LongArrow ? '>' : '-';

--- a/PlatCurses.h
+++ b/PlatCurses.h
@@ -4,6 +4,8 @@
 #ifndef PLAT_CURSES_H
 #define PLAT_CURSES_H
 
+#include <curses.h>
+
 namespace Scintilla::Internal {
 
 class FontImpl : public Font {
@@ -137,8 +139,6 @@ void init_colors();
 short term_color(ColourRGBA color);
 short term_color(short color);
 
-} // namespace Scintilla::Internal
-
 /**
  * Returns the given Scintilla `WindowID` as a curses `WINDOW`.
  * @param w A Scintilla `WindowID`.
@@ -158,11 +158,25 @@ short term_color(short color);
 #define SCI_COLOR_PAIR(f, b) ((b) * ((COLORS < 16) ? 8 : 16) + (f) + 1)
 
 /**
- * Returns a curses color pair from the given fore and back colors.
+ * Returns a curses attribute from the given fore and back colors.
  * @param f Foreground color, either a Scintilla color or curses color.
  * @param b Background color, either a Scintilla color or curses color.
- * @return curses color pair suitable for calling `COLOR_PAIR()` with.
+ * @return curses attribute
  */
-#define term_color_pair(f, b) SCI_COLOR_PAIR(term_color(f), term_color(b))
+template<typename FT, typename BT>
+static inline attr_t term_color_attr(FT f, BT b)
+{
+	if (has_colors())
+		return COLOR_PAIR(SCI_COLOR_PAIR(term_color(f), term_color(b)));
+
+	/*
+	 * Basic support for monochrome terminals:
+	 * Every background, that is not black is assumed to be a
+	 * dark-on-bright area, rendered in reverse.
+	 */
+	return term_color(b) != COLOR_BLACK ? A_REVERSE : 0;
+}
+
+} // namespace Scintilla::Internal
 
 #endif

--- a/ScintillaCurses.cxx
+++ b/ScintillaCurses.cxx
@@ -267,12 +267,12 @@ void ScintillaCurses::SetVerticalScrollPos() {
 	WINDOW *w = GetWINDOW();
 	int maxy = getmaxy(w), maxx = getmaxx(w);
 	// Draw the gutter.
-	wattr_set(w, 0, term_color_pair(COLOR_WHITE, COLOR_BLACK), nullptr);
+	wattrset(w, term_color_attr(COLOR_WHITE, COLOR_BLACK));
 	for (int i = 0; i < maxy; i++) mvwaddch(w, i, maxx - 1, ACS_CKBOARD);
 	// Draw the bar.
 	scrollBarVPos =
 		static_cast<int>(static_cast<float>(topLine) / (MaxScrollPos() + LinesOnScreen() - 1) * maxy);
-	wattr_set(w, 0, term_color_pair(COLOR_BLACK, COLOR_WHITE), nullptr);
+	wattrset(w, term_color_attr(COLOR_BLACK, COLOR_WHITE));
 	for (int i = scrollBarVPos; i < scrollBarVPos + scrollBarHeight; i++)
 		mvwaddch(w, i, maxx - 1, ' ');
 }
@@ -282,11 +282,11 @@ void ScintillaCurses::SetHorizontalScrollPos() {
 	WINDOW *w = GetWINDOW();
 	int maxy = getmaxy(w), maxx = getmaxx(w);
 	// Draw the gutter.
-	wattr_set(w, 0, term_color_pair(COLOR_WHITE, COLOR_BLACK), nullptr);
+	wattrset(w, term_color_attr(COLOR_WHITE, COLOR_BLACK));
 	for (int i = 0; i < maxx; i++) mvwaddch(w, maxy - 1, i, ACS_CKBOARD);
 	// Draw the bar.
 	scrollBarHPos = static_cast<int>(static_cast<float>(xOffset) / scrollWidth * maxx);
-	wattr_set(w, 0, term_color_pair(COLOR_BLACK, COLOR_WHITE), nullptr);
+	wattrset(w, term_color_attr(COLOR_BLACK, COLOR_WHITE));
 	for (int i = scrollBarHPos; i < scrollBarHPos + scrollBarWidth; i++)
 		mvwaddch(w, maxy - 1, i, ' ');
 }
@@ -397,7 +397,7 @@ void ScintillaCurses::CreateCallTipWindow(PRectangle rc) {
 		surface->Init(wid);
 		dynamic_cast<SurfaceImpl *>(surface.get())->isCallTip = true;
 		ct.PaintCT(surface.get());
-		wattr_set(_WINDOW(wid), 0, term_color_pair(COLOR_WHITE, COLOR_BLACK), nullptr);
+		wattrset(_WINDOW(wid), term_color_attr(COLOR_WHITE, COLOR_BLACK));
 		box(_WINDOW(wid), '|', '-');
 		wnoutrefresh(_WINDOW(wid));
 	}


### PR DESCRIPTION
curses does not automatically emulate colors with reverse text on monochrome terminals.

Scintilla however is based on RGB colors, so theoretically we could get the RGB components of the foreground and background colors and calculate a contrast value that tells us wether the text is light-on-dark or dark-on-light. Instead we implemented a much simpler heuristic: on terminals without color support, we render text in reverse if the background color is not black (COLOR_BLACK). This should at least work if you didn't redefine colors with init_color().

This actually makes Scinterm usable in historic terminals like VT100, VT220 or VT240. Perhaps more importantly, $TERM may be set to vt100 or some other conservative value even on modern serial terminal connections. Also, there are monochrome variants of most terminals in terminfo.

This introduces a new term_color_attr() which returns either a color attribute *or* A_REVERSE. This can only be passed to "legacy" attribute setting functions. However since Scinterm practically restricts us to a palette of 16 colors, the "legacy" API should be safe to use.