### PR TITLE
fixed Colors::Pair() lookup on platforms where sizeof(attr_t) > sizeof(short)

### DIFF
--- a/PlatCurses.cxx
+++ b/PlatCurses.cxx
@@ -215,6 +215,7 @@ void SurfaceImpl::PolyLine(const Point *pts, size_t npts, Stroke stroke) {
 		attr_t attrs = mvwinch(win, y, x) & A_ATTRIBUTES;
 		short pair = PAIR_NUMBER(attrs), unused, back = COLOR_BLACK;
 		if (pair > 0) pair_content(pair, &unused, &back);
+		attrs &= ~A_COLOR;
 		mvwchgat(win, y, x, 1, attrs | A_UNDERLINE,
 			PAIR_NUMBER(Colors::Pair(stroke.colour, Colors::Find(back))), nullptr);
 	}
@@ -287,6 +288,7 @@ void SurfaceImpl::AlphaRectangle(PRectangle rc, XYPOSITION /*cornerSize*/, FillS
 		attr_t attrs = mvwinch(win, y, x) & A_ATTRIBUTES;
 		short pair = PAIR_NUMBER(attrs), fore = COLOR_WHITE, unused;
 		if (pair > 0) pair_content(pair, &fore, &unused);
+		attrs &= ~A_COLOR;
 		mvwchgat(win, y, x, 1, attrs, PAIR_NUMBER(Colors::Pair(Colors::Find(fore), fill)), nullptr);
 	}
 }

--- a/PlatCurses.cxx
+++ b/PlatCurses.cxx
@@ -140,11 +140,11 @@ attr_t Colors::Pair(const ColourRGBA &fore, const ColourRGBA &back) {
 	if (!has_colors()) return back.Opaque() == Black ? 0 : A_REVERSE;
 	auto &pairs = instance().pairs;
 	const auto pair = std::make_pair(instance().get(fore), instance().get(back));
-	if (const auto entry = pairs.find(pair); entry != pairs.end()) return entry->second;
+	if (const auto entry = pairs.find(pair); entry != pairs.end()) return COLOR_PAIR(entry->second);
 	if (instance().pairOffset + pairs.size() >= static_cast<size_t>(COLOR_PAIRS)) return 0;
 	const short n = instance().pairOffset + pairs.size() + 1; // starts from 1, not 0
 	init_pair(n, pair.first, pair.second);
-	pairs.emplace(pair, COLOR_PAIR(n));
+	pairs.emplace(pair, n);
 	return COLOR_PAIR(n);
 }
 


### PR DESCRIPTION
Colors::pairs was supposed to contain a map to pair numbers (short), but actually contained attributes (COLOR_PAIR).
Instead of fixing the Colors::pairs declaration - which would waste memory - I made the Colors::Pair() conform to the declaration and only store pair numbers.

This was broken for instance on PDCurses.